### PR TITLE
feat: Work without datasource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [Prisma Client Extension](https://www.prisma.io/docs/concepts/components/pr
 
 ## Requirements
 
-Works best with Prisma 5.1+. Can work with earlier versions (4.16.2+) if [no result extensions](https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions/result) are used at the same time.
+Requires Prisma 5.2+.
 
 ## Installation
 
@@ -38,12 +38,10 @@ import { readReplicas } from '@prisma/extension-read-replicas
 
 const prisma = new PrismaClient().$extends(
   readReplicas({
-    db: 'postgresql://replica.example.com:5432/db',
+    url: 'postgresql://replica.example.com:5432/db',
   }),
 )
 ```
-
-Where `db` is the name of your datasource (`datasource` block in the schema file).
 
 All non-transactional read queries will now be executed against the defined replica.  
 Write queries and transactions will be executed against the primary server.
@@ -55,7 +53,7 @@ You can also initialize the extension with an array of replica connection string
 ```ts
 const prisma = new PrismaClient().$extends(
   readReplicas({
-    db: [
+    url: [
       'postgresql://replica-1.example.com:5432/db',
       'postgresql://replica-2.example.com:5432/db',
     ],

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { readReplicas } from '..'
 
-const client = new PrismaClient().$extends(readReplicas({ db: process.env.REPLICA_URL! }))
+const client = new PrismaClient().$extends(readReplicas({ url: process.env.REPLICA_URL! }))
 
 async function main() {
   await client.user.deleteMany()

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@prisma/client": "5.1.0-integration-fix-result-query-ext.1",
+    "@prisma/client": "5.2.0-dev.72",
     "@swc/core": "^1.3.73",
     "@swc/jest": "^0.2.27",
     "@types/debug": "^4.1.8",
@@ -57,7 +57,7 @@
     "jest": "^29.6.2",
     "lint-staged": "^13.2.3",
     "prettier": "^3.0.0",
-    "prisma": "5.1.0-integration-fix-result-query-ext.1",
+    "prisma": "5.2.0-dev.72",
     "typescript": "^5.1.6"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ dependencies:
 
 devDependencies:
   '@prisma/client':
-    specifier: 5.1.0-integration-fix-result-query-ext.1
-    version: 5.1.0-integration-fix-result-query-ext.1(prisma@5.1.0-integration-fix-result-query-ext.1)
+    specifier: 5.2.0-dev.72
+    version: 5.2.0-dev.72(prisma@5.2.0-dev.72)
   '@swc/core':
     specifier: ^1.3.73
     version: 1.3.73
@@ -65,8 +65,8 @@ devDependencies:
     specifier: ^3.0.0
     version: 3.0.0
   prisma:
-    specifier: 5.1.0-integration-fix-result-query-ext.1
-    version: 5.1.0-integration-fix-result-query-ext.1
+    specifier: 5.2.0-dev.72
+    version: 5.2.0-dev.72
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
@@ -975,8 +975,8 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@prisma/client@5.1.0-integration-fix-result-query-ext.1(prisma@5.1.0-integration-fix-result-query-ext.1):
-    resolution: {integrity: sha512-FejHVLMLJoJKDlMCw15uk5MvAOWDbmXmRQyqkZSZhSLbw+DpV8tyUb52Q1XqMAedzS85kMwDLaTPZhZuD37cMg==}
+  /@prisma/client@5.2.0-dev.72(prisma@5.2.0-dev.72):
+    resolution: {integrity: sha512-pkYvY2HqQgiFE2cIShU/Piow5aJELsZd08keAz7eYWVJaGPcH86zKjUTo+6FRONNXipaM04pZB5knLtANyta7g==}
     engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
@@ -985,16 +985,16 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 5.1.0-22.4b132e0d5319952d155d8bbe2ba802464ebf8c6e
-      prisma: 5.1.0-integration-fix-result-query-ext.1
+      '@prisma/engines-version': 5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f
+      prisma: 5.2.0-dev.72
     dev: true
 
-  /@prisma/engines-version@5.1.0-22.4b132e0d5319952d155d8bbe2ba802464ebf8c6e:
-    resolution: {integrity: sha512-XlybQI2nuNV0TMtu+koasybFniRslGNuq0WNHNVqyJ6dmBiTRbhofns+IFLqb0dqsxxP7kCw/XRhxgq1YvmOvw==}
+  /@prisma/engines-version@5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f:
+    resolution: {integrity: sha512-jsnKT5JIDIE01lAeCj2ghY9IwxkedhKNvxQeoyLs6dr4ZXynetD0vTy7u6wMJt8vVPv8I5DPy/I4CFaoXAgbtg==}
     dev: true
 
-  /@prisma/engines@5.1.0-integration-fix-result-query-ext.1:
-    resolution: {integrity: sha512-w4tfW5Agm1BNBdq0vZJrFVJ8e25n8T8jvld1E0uim21S2wCyMOsQHiLxswx3qecrIc5nhmybzOnWPuLy5IGquw==}
+  /@prisma/engines@5.2.0-dev.72:
+    resolution: {integrity: sha512-KnS2RsKpEr+T6+QBjyVB2JSeLjmCgJUaeqKloyhVbRyKdVVSVFZEHa+4wspAapf7pNfoXov/cXkMaZq0Vs+dUg==}
     requiresBuild: true
     dev: true
 
@@ -3215,13 +3215,13 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /prisma@5.1.0-integration-fix-result-query-ext.1:
-    resolution: {integrity: sha512-NSlLVNlxuvdvqjgyqkJzwVNs07BbXhcOeQYH4ejny//82rMSYpYEIpHoFCyMQj8GPlfV8m+Uh6pbgmO/qbaH6Q==}
+  /prisma@5.2.0-dev.72:
+    resolution: {integrity: sha512-ITtvi8N8tqLr+nYh/i1i8W/9V8vzA66a7VDy85dxymFUZ0qoEcIk1PTYgLxExy8MrfdmlAh8E6525oVNHbJJEA==}
     engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 5.1.0-integration-fix-result-query-ext.1
+      '@prisma/engines': 5.2.0-dev.72
     dev: true
 
   /prompts@2.4.2:

--- a/src/ReplicaManager.ts
+++ b/src/ReplicaManager.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client/extension'
 
 type PrismaConstructorOptions = {
-  datasources?: Record<string, { url: string }>
+  datasourceUrl?: string
 }
 
 export type ConfigureReplicaCallback = (client: PrismaClient) => PrismaClient
@@ -12,21 +12,16 @@ interface PrismaClientConstructor {
 type ReplicaManagerOptions = {
   clientConstructor: PrismaClientConstructor
   replicaUrls: string[]
-  datasourceName: string
   configureCallback: ConfigureReplicaCallback | undefined
 }
 
 export class ReplicaManager {
   private _replicaClients: PrismaClient[]
 
-  constructor({ replicaUrls, datasourceName, clientConstructor, configureCallback }: ReplicaManagerOptions) {
-    this._replicaClients = replicaUrls.map((url) => {
+  constructor({ replicaUrls, clientConstructor, configureCallback }: ReplicaManagerOptions) {
+    this._replicaClients = replicaUrls.map((datasourceUrl) => {
       const client = new clientConstructor({
-        datasources: {
-          [datasourceName]: {
-            url,
-          },
-        },
+        datasourceUrl,
       })
 
       if (configureCallback) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { Prisma } from '@prisma/client/extension'
 import { ConfigureReplicaCallback, ReplicaManager } from './ReplicaManager'
 
 export type ReplicasOptions = {
-  [datasource: string]: string | string[]
+  url: string | string[]
 }
 
 const debug = createDebug('prisma:replicasExtension')
@@ -31,17 +31,16 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
     if (!datasourceName) {
       throw new Error(`Read replicas options must specify a datasource`)
     }
-    let urls = options[datasourceName]
-    if (typeof urls === 'string') {
-      urls = [urls]
-    } else if (!Array.isArray(urls)) {
+    let replicaUrls = options.url
+    if (typeof replicaUrls === 'string') {
+      replicaUrls = [replicaUrls]
+    } else if (!Array.isArray(replicaUrls)) {
       throw new Error(`Replica URLs must be a string or list of strings`)
     }
 
     const replicaManager = new ReplicaManager({
-      replicaUrls: urls,
+      replicaUrls,
       clientConstructor: PrismaClient,
-      datasourceName,
       configureCallback: configureReplicaClient,
     })
 

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -15,7 +15,7 @@ function createPrisma() {
     .$extends(
       readReplicas(
         {
-          db: process.env.REPLICA_URL!,
+          url: process.env.REPLICA_URL!,
         },
         (client) =>
           (client as PrismaClient).$extends({


### PR DESCRIPTION
Changes API in a way that does not require knowing datasource name
anymore. See readme for examples.

Since this uses new `datasourceUrl` shortcut, introduced in 5.2, it
also bumps minimum required version.

Close prisma/team-orm#270
