### PR TITLE
docs(README): Make limitations a list + fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ prisma.$primary().user.findMany({ where: { ... }})
     .$extends(rlsExtension())
     .$extends(
       readReplicas({
-        db: 'postgresql://replica.example.com:5432/db',
+        url: 'postgresql://replica.example.com:5432/db',
       }),
     )
   ```
-- If you are using the read replicas extension with Prisma version below 5.1, any result extensions will not work.
+- If you use the read replicas extension with Prisma version below 5.1, any result extensions will not work.

--- a/README.md
+++ b/README.md
@@ -73,17 +73,15 @@ prisma.$primary().user.findMany({ where: { ... }})
 
 ### Caveats and limitations
 
-At the moment, if you are using this read replicas extension alongside other extensions, this extension should be applied last:
-
-```ts
-const prisma = new PrismaClient()
-  .$extends(withAccelerate())
-  .$extends(rlsExtension())
-  .$extends(
-    readReplicas({
-      db: 'postgresql://replica.example.com:5432/db',
-    }),
-  )
-```
-
-If you are using the read replicas extension with Prisma version below 5.1, any result extensions will not work.
+- At the moment, if you are using this read replicas extension alongside other extensions, this extension should be applied last:
+  ```ts
+  const prisma = new PrismaClient()
+    .$extends(withAccelerate())
+    .$extends(rlsExtension())
+    .$extends(
+      readReplicas({
+        db: 'postgresql://replica.example.com:5432/db',
+      }),
+    )
+  ```
+- If you are using the read replicas extension with Prisma version below 5.1, any result extensions will not work.


### PR DESCRIPTION
List makes it easier to see that there are 2 limitations, and code example now actually works with new API.