### PR TITLE
Support empty replica list

### DIFF
--- a/src/ReplicaManager.ts
+++ b/src/ReplicaManager.ts
@@ -39,7 +39,7 @@ export class ReplicaManager {
     await Promise.all(this._replicaClients.map((client) => client.$disconnect()))
   }
 
-  pickReplica(): PrismaClient | undefined {
+  pickReplica(): PrismaClient {
     return this._replicaClients[Math.floor(Math.random() * this._replicaClients.length)]
   }
 }

--- a/src/ReplicaManager.ts
+++ b/src/ReplicaManager.ts
@@ -39,7 +39,7 @@ export class ReplicaManager {
     await Promise.all(this._replicaClients.map((client) => client.$disconnect()))
   }
 
-  pickReplica(): PrismaClient {
+  pickReplica(): PrismaClient | undefined {
     return this._replicaClients[Math.floor(Math.random() * this._replicaClients.length)]
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,8 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
       replicaUrls = [replicaUrls]
     } else if (!Array.isArray(replicaUrls)) {
       throw new Error(`Replica URLs must be a string or list of strings`)
+    } else if (replicaUrls.length === 0) {
+      throw new Error(`At least one replica URL must be specified`)
     }
 
     const replicaManager = new ReplicaManager({
@@ -69,7 +71,7 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
             return query(args)
           }
           if (readOperations.includes(operation)) {
-            const replica = replicaManager.pickReplica() ?? client
+            const replica = replicaManager.pickReplica()
             if (model) {
               return replica[model][operation](args)
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
             return query(args)
           }
           if (readOperations.includes(operation)) {
-            const replica = replicaManager.pickReplica()
+            const replica = replicaManager.pickReplica() ?? client
             if (model) {
               return replica[model][operation](args)
             }


### PR DESCRIPTION
In my testing, one of the things I noticed is that an empty list of replicas will lead to an unexpected undefined value. While I believe it would make sense for an empty list could be problematic in other ways, in situations like integration testing it may not make sense to set up a full replica instance.

This PR adds a coalesce to ensure that even when no replicas are instantiated, a valid Prisma instance (the primary) is returned. This way, we don't heave to worry about checking for an empty list and setting up types to condition on whether it is a replica or primary instance throughout the codebase.