### PR TITLE
Expose replicas as $replica()

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 export DATABASE_URL=postgresql://prisma:prisma@localhost:6432/test
-export REPLICA_URL=postgresql://prisma:prisma@localhost:6432/test
+export REPLICA_URL=postgresql://prisma:prisma@localhost:7432/test

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 export DATABASE_URL=postgresql://prisma:prisma@localhost:6432/test
-export REPLICA_URL=postgresql://prisma:prisma@localhost:7432/test
+export REPLICA_URL=postgresql://prisma:prisma@localhost:6432/test

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -77,6 +77,26 @@ test('write query is executed against primary', async () => {
   expect(logs).toEqual([{ server: 'primary', operation: 'updateMany' }])
 })
 
+test('$executeRaw and $executeRawUnsafe are executed against primary', async () => {
+  await prisma.$executeRaw`SELECT 1;`
+  await prisma.$executeRawUnsafe('SELECT $1 as id;', 1)
+
+  expect(logs).toEqual([
+    { server: 'primary', operation: '$executeRaw' },
+    { server: 'primary', operation: '$executeRawUnsafe' },
+  ])
+})
+
+test('$executeRaw and $executeRawUnsafe are executed against replica if $replica() is used', async () => {
+  await prisma.$replica().$executeRaw`SELECT 1;`
+  await prisma.$replica().$executeRawUnsafe('SELECT $1 as id;', 1)
+
+  expect(logs).toEqual([
+    { server: 'replica', operation: '$executeRaw' },
+    { server: 'replica', operation: '$executeRawUnsafe' },
+  ])
+})
+
 test('read query is executed against primary if $primary() is used', async () => {
   await prisma.$primary().user.findMany()
 


### PR DESCRIPTION
To unstall https://github.com/prisma/extension-read-replicas/pull/18, I'm setting up a `$replica()` client-level call that forces use of a randomly-selected replica. This allows maximal developer control without sacrificing clarity for now, as suggested in https://github.com/prisma/extension-read-replicas/pull/18#issuecomment-1741314933.