### PR TITLE
Document `$replica()` method, remove not working `queryRaw` routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ const prisma = new PrismaClient().$extends(
 All non-transactional read queries will now be executed against the defined replica.  
 Write queries and transactions will be executed against the primary server.
 
-**Note**: `queryRaw` and `executeRaw` are always executed against primary server by default since
-extension can not know for sure if particular raw query would read or write to the DB.
-Use `$replica()` method to explicitly route the request to read replica.
+**Note**: `queryRaw` and `executeRaw` are always executed against the primary server by default since
+the extension can not know for sure if a particular raw query would read or write to the database.
+Use the `$replica()` method to explicitly route the request to a read replica.
 
 ### Multiple replicas
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,13 @@ If you want to execute a read query against the primary server, you can use the 
 prisma.$primary().user.findMany({ where: { ... }})
 ```
 
-### Forcing request to go through replica
+### Forcing request to go through a replica
 
-Sometimes you might want to do the opposite and route the request to the replica even though
-it will be routed to primary by default. In that case, you can use `$replica()` method:
+Sometimes you might want to do the opposite and route the request to a replica even though
+it will be routed to primary by default. In that case, you can use the `$replica()` method:
 
 ```ts
 prisma.$replica().$queryRaw`SELECT ...`
-```
-
-If multiple replicas are configured, random one will be selected.
 
 ### Caveats and limitations
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ const prisma = new PrismaClient().$extends(
 All non-transactional read queries will now be executed against the defined replica.  
 Write queries and transactions will be executed against the primary server.
 
+**Note**: `queryRaw` and `executeRaw` are always executed against primary server by default since
+extension can not know for sure if particular raw query would read or write to the DB.
+Use `$replica()` method to explicitly route the request to read replica.
+
 ### Multiple replicas
 
 You can also initialize the extension with an array of replica connection strings:
@@ -70,6 +74,17 @@ If you want to execute a read query against the primary server, you can use the 
 ```ts
 prisma.$primary().user.findMany({ where: { ... }})
 ```
+
+### Forcing request to go through replica
+
+Sometimes you might want to do the opposite and route the request to the replica even though
+it will be routed to primary by default. In that case, you can use `$replica()` method:
+
+```ts
+prisma.$replica().$queryRaw`SELECT ...`
+```
+
+If multiple replicas are configured, random one will be selected.
 
 ### Caveats and limitations
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,8 +15,6 @@ const readOperations = [
   'groupBy',
   'aggregate',
   'count',
-  'queryRaw',
-  'queryRawUnsafe',
   'findRaw',
   'aggregateRaw',
 ]


### PR DESCRIPTION
Doc for the feature added in #21.
Since we decided that queryRaw would always go to primary by default,
we are also removing non-working code for routing it to replica instead.
