### PR TITLE
ci(publish.yml): add npm provenance statements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     name: Build and publish
     runs-on: ubuntu-latest
+    permissions:
+      # required for publishing to npm with --provenance
+      # see https://docs.npmjs.com/generating-provenance-statements
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -19,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-          node-version: 16
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -34,3 +38,5 @@ jobs:
           pnpm publish --access public --tag latest --no-git-checks
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # https://docs.npmjs.com/generating-provenance-statements
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
See https://docs.npmjs.com/generating-provenance-statements This increases supply-chain security for the packages, since it publicly establish where a package was built (here, in GitHub Actions) and who published a package.

See https://prisma-company.slack.com/archives/C1FPU5FPT/p1698675822988359

I switched to Node.js 20, like in prisma/prisma for publishing (we need to have a more recent version of npm for provenance statements)

Similar to https://github.com/prisma/engines-wrapper/pull/476