### PR TITLE
Add options for replica clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ const prisma = new PrismaClient().$extends(
 
 In this case, a replica for each read query will be selected randomly.
 
+### Pre-configured clients
+
+If you want to supply additional options to replica client, you can also pass pre-configured read clients instead of urls:
+
+```ts
+const replicaClient = new PrismaClient({
+  datasourceUrl: 'postgresql://replica.example.com:5432/db'
+  log: [{ level: 'query', emit: 'event' }]
+})
+
+replicaClient.$on('query', (event) => console.log('Replica event', event))
+
+const prisma = new PrismaClient().$extends(
+  readReplicas({
+    replicas: [
+      replicaClient
+    ],
+  }),
+)
+```
+
 ### Bypassing the replicas
 
 If you want to execute a read query against the primary server, you can use the `$primary()` method on your extended client:

--- a/src/ReplicaManager.ts
+++ b/src/ReplicaManager.ts
@@ -1,27 +1,26 @@
 import { PrismaClient } from '@prisma/client/extension'
-
-type PrismaConstructorOptions = {
-  datasourceUrl?: string
-}
+import { PrismaClientOptions } from '@prisma/client/runtime/library'
 
 export type ConfigureReplicaCallback = (client: PrismaClient) => PrismaClient
 interface PrismaClientConstructor {
-  new (options?: PrismaConstructorOptions): PrismaClient
+  new (options?: PrismaClientOptions): PrismaClient
 }
 
 type ReplicaManagerOptions = {
   clientConstructor: PrismaClientConstructor
   replicaUrls: string[]
+  replicaClientOptions?: PrismaClientOptions
   configureCallback: ConfigureReplicaCallback | undefined
 }
 
 export class ReplicaManager {
   private _replicaClients: PrismaClient[]
 
-  constructor({ replicaUrls, clientConstructor, configureCallback }: ReplicaManagerOptions) {
+  constructor({ replicaUrls, replicaClientOptions, clientConstructor, configureCallback }: ReplicaManagerOptions) {
     this._replicaClients = replicaUrls.map((datasourceUrl) => {
       const client = new clientConstructor({
         datasourceUrl,
+        ...replicaClientOptions,
       })
 
       if (configureCallback) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,11 @@
 import { Prisma } from '@prisma/client/extension.js'
 
 import { ConfigureReplicaCallback, ReplicaManager } from './ReplicaManager'
+import { PrismaClientOptions } from '@prisma/client/runtime/library'
 
 export type ReplicasOptions = {
   url: string | string[]
+  replicaClientOptions?: PrismaClientOptions
 }
 
 const readOperations = [
@@ -38,6 +40,7 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
     const replicaManager = new ReplicaManager({
       replicaUrls,
       clientConstructor: PrismaClient,
+      replicaClientOptions: options.replicaClientOptions,
       configureCallback: configureReplicaClient,
     })
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,9 @@ import { ConfigureReplicaCallback, ReplicaManager, type ReplicaManagerOptions } 
 export type ReplicasOptions =
   | {
       url: string | string[]
+      replicas?: undefined
     }
-  | { replicas: PrismaClient[] }
+  | { url?: undefined; replicas: PrismaClient[] }
 
 const readOperations = [
   'findFirst',
@@ -35,7 +36,7 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
 
     let replicaManagerOptions: ReplicaManagerOptions
 
-    if ('url' in options) {
+    if (options.url) {
       let replicaUrls = options.url
 
       if (typeof replicaUrls === 'string') {
@@ -44,7 +45,7 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
         throw new Error(`Replica URLs must be a string or list of strings`)
       }
 
-      if (replicaUrls.length === 0) {
+      if (replicaUrls?.length === 0) {
         throw new Error(`At least one replica URL must be specified`)
       }
 
@@ -53,7 +54,7 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
         clientConstructor: PrismaClient,
         configureCallback: configureReplicaClient,
       }
-    } else if ('replicas' in options) {
+    } else if (options.replicas) {
       if (options.replicas.length === 0) {
         throw new Error(`At least one replica must be specified`)
       }

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -76,6 +76,36 @@ test('client throws an error when given an empty read replica list', async () =>
   expect(createInstance).toThrowError('At least one replica must be specified')
 })
 
+test('client throws an error when given both a URL and a list of replicas', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const clientModule = require('./client')
+  const replicaPrisma = new clientModule.PrismaClient({
+    datasourceUrl: process.env.REPLICA_URL!,
+    log: [{ emit: 'event', level: 'query' }],
+  })
+  const createInstance = () =>
+    basePrisma.$extends(
+      readReplicas({
+        url: process.env.REPLICA_URL!,
+        replicas: [replicaPrisma],
+      }),
+    )
+
+  expect(createInstance).toThrowError(`Only one of 'url' or 'replicas' can be specified`)
+})
+
+test('client throws an error when given an invalid read replicas options', async () => {
+  const createInstance = () =>
+    basePrisma.$extends(
+      readReplicas({
+        // @ts-expect-error
+        foo: 'bar',
+      }),
+    )
+
+  expect(createInstance).toThrowError('Invalid read replicas options')
+})
+
 test('read query is executed against replica', async () => {
   await prisma.user.findMany()
 


### PR DESCRIPTION
This PR resolves #20 .

Changes:
- Updated ReplicaManager.ts to accept replicaClientOptions.
- Fix instantiation of Prisma Clients to include replicaClientOptions.
- Updated PrismaClientConstructor type.
- readReplicas in extension.ts now supports replicaClientOptions.
- Added a test for replica client options.

Inheriting the configuration from the primary, as discussed [here](https://github.com/prisma/extension-read-replicas/issues/20#issuecomment-1751280873),  seems challenging because the constructor arguments are unavailable from the instance. 

If implementing for this inheritance, it seems to make modifications to the Prisma Client core, allowing for the retrieval of constructor arguments from the instance.

Close #20 