### PR TITLE
Support Fluent API in read operations

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,22 +75,40 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
       },
 
       query: {
-        $allOperations({
+        async $allOperations({
           args,
           model,
           operation,
           query,
-          // @ts-expect-error
-          __internalParams: { transaction },
+          // @ts-expect-error We make use of internal APIs to make this extension work.
+          __internalParams: { transaction, dataPath },
         }) {
           if (transaction) {
             return query(args)
           }
           if (readOperations.includes(operation)) {
             const replica = replicaManager.pickReplica()
+
             if (model) {
-              return replica[model][operation](args)
+              let result = await replica[model][operation](args)
+
+              // HACK: Work around lack of read replica support by leveraging
+              // dataPath. We expect dataPath to be in the following format:
+              // [ 'select', 'fieldNameOne', 'select', 'fieldNameTwo' ]
+              // Given this format, we'll read every second string to get the
+              // expected response type.
+              const path = dataPath as string[]
+              for (let i = 1; i < path.length; i += 2) {
+                if (Array.isArray(result)) {
+                  result = result.flatMap((item) => item?.[path[i]])
+                } else {
+                  result = result?.[path[i]]
+                }
+              }
+
+              return result
             }
+
             return replica[operation](args)
           }
 

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -71,6 +71,24 @@ test('read query is executed against replica', async () => {
   expect(logs).toEqual([{ server: 'replica', operation: 'findMany' }])
 })
 
+test('read query can resolve fluent queries against replica', async () => {
+  await prisma.user.create({
+    data: {
+      email: 'user@example.com',
+      posts: {
+        create: [{}],
+      },
+    },
+  })
+  const res = await prisma.user.findFirst().posts().author().posts().author()
+
+  expect(logs).toEqual([
+    { server: 'primary', operation: 'create' },
+    { server: 'replica', operation: 'findFirst' },
+  ])
+  expect(res).toMatchObject([{ email: 'user@example.com' }])
+})
+
 test('write query is executed against primary', async () => {
   await prisma.user.updateMany({ data: {} })
 

--- a/tests/prisma/schema.prisma
+++ b/tests/prisma/schema.prisma
@@ -9,6 +9,13 @@ datasource db {
 }
 
 model User {
-    id    String @id @default(uuid())
-    email String @unique
+    id    String @id @db.Uuid @default(uuid())
+    email String
+    posts Post[] @relation("PostToUser")
+}
+
+model Post {
+    id String @id @default(uuid())
+    authorId String @db.Uuid
+    author User @relation("PostToUser", fields: [authorId], references: [id])
 }


### PR DESCRIPTION
Closes #12 with the solution approach described in https://github.com/prisma/extension-read-replicas/issues/12#issuecomment-2059456680. I further productionized it to make sure it handled arrays correctly, and added some tests to make sure of that fact.

This, of course, is a workaround at best and a terrible hack at worst. That said, the lack of support for Fluent API is significantly hampering adoption of client extensions, and this behavior is backed with an integration test, so we will get warning if Prisma Client breaks this behavior. I would much prefer resolution of https://github.com/prisma/prisma/issues/24653 in the long term.