### PR TITLE
feat: allow to select default read client

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,8 +6,9 @@ export type ReplicasOptions =
   | {
       url: string | string[]
       replicas?: undefined
+      defaultReadClient?: 'primary' | 'replica'
     }
-  | { url?: undefined; replicas: PrismaClient[] }
+  | { url?: undefined; replicas: PrismaClient[]; defaultReadClient: 'replica' }
 
 const readOperations = [
   'findFirst',
@@ -112,6 +113,11 @@ export const readReplicas = (options: ReplicasOptions, configureReplicaClient?: 
           if (transaction) {
             return query(args)
           }
+
+          if (options.defaultReadClient === 'primary') {
+            return query(args)
+          }
+
           if (readOperations.includes(operation)) {
             const replica = replicaManager.pickReplica()
             if (model) {


### PR DESCRIPTION
This pull request introduces enhancements to the read replica functionality by adding a new option for the default read client, modifying the query execution logic.

It opt-in for `$replicas` like the legacy behavior but allow to opt-in for `$primary` instead.

It's a proposal to fix #35